### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/irwanx/database/security/code-scanning/2](https://github.com/irwanx/database/security/code-scanning/2)

Add an explicit `permissions` block for the `build` job to limit `GITHUB_TOKEN` scope to the minimum needed.  
Best fix without changing functionality: set `contents: read` under `jobs.build` (same level as `runs-on`). This preserves all current behavior (`checkout` can still read repository contents) while satisfying CodeQL and least-privilege guidance.

Change needed in:
- **File:** `.github/workflows/npm-publish-github-packages.yml`
- **Region:** `jobs.build` section, immediately before or after `runs-on`.

No imports, methods, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow security configuration to improve process integrity and safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irwanx/database/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->